### PR TITLE
inject scripts at documentcontentloaded instead of window.load

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,7 +38,8 @@
 
   "content_scripts": [{
     "matches": ["*://*/*"],
-    "js": ["js/dom.js", "js/content.js"]
+    "js": ["js/dom.js", "js/content.js"],
+    "run_at": "document_end"
   }],
 
   "permissions": ["tabs", "storage", "*://*/*", "unlimitedStorage", "notifications"]


### PR DESCRIPTION
I find the injection is too slow. Would love it happening in DCL instead.
